### PR TITLE
ci(scripts): fix commitlint script

### DIFF
--- a/scripts/commitilint_range.sh
+++ b/scripts/commitilint_range.sh
@@ -6,8 +6,12 @@ set -euo pipefail
 PULL_REQUEST_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | cut -d/ -f7)
 UPSTREAM_PROJECT_USERNAME=$(echo "${CIRCLE_PULL_REQUEST}" | cut -d/ -f4)
 CURL_URL="https://api.github.com/repos/${UPSTREAM_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PULL_REQUEST_NUMBER}"
-PULL_REQUEST_DETAILS=$(curl ${CURL_URL})
 
+if [ -z "${CIRCLE_PULL_REQUEST}" ] || [ -z "${PULL_REQUEST_NUMBER}" ] || [ -z "${UPSTREAM_PROJECT_USERNAME}" ]; then
+    exit 0;
+fi
+
+PULL_REQUEST_DETAILS=$(curl "${CURL_URL}")
 FROM=$(echo "${PULL_REQUEST_DETAILS}" | jq -r .base.sha)
 TO=$(echo "${PULL_REQUEST_DETAILS}" | jq -r .head.sha)
 


### PR DESCRIPTION
The script was failing on non pull request pipelines, since in that case
we should already have verified the commits, I'm disabling it.