### PR TITLE
fix: react version in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^4.4.4"
   },
   "peerDependencies": {
-    "react": "16"
+    "react": "^16.8.0 || ^17.0.2"
   },
   "scripts": {
     "build": "rollup --config",


### PR DESCRIPTION
The minimum supported react version is [16.8 because of react hooks](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html).

The [react version 17 ](https://reactjs.org/blog/2020/10/20/react-v17.html)doesn't cause any trouble.

React 18 wasn't tested yet with this lib.